### PR TITLE
🚑  UserTeam 테이블에 유저가 속했던 팀 아이디 보존하는 historyTeamId 컬럼 추가 / 팀에 속해있을 때의 팀 생성 예외처리

### DIFF
--- a/src/main/java/com/beotkkotthon/areyousleeping/controller/TeamController.java
+++ b/src/main/java/com/beotkkotthon/areyousleeping/controller/TeamController.java
@@ -1,21 +1,16 @@
 package com.beotkkotthon.areyousleeping.controller;
 
 import com.beotkkotthon.areyousleeping.annotation.UserId;
-import com.beotkkotthon.areyousleeping.domain.Team;
 import com.beotkkotthon.areyousleeping.dto.global.ResponseDto;
 import com.beotkkotthon.areyousleeping.dto.request.TeamSaveDto;
-import com.beotkkotthon.areyousleeping.dto.response.TeamResponseDto;
 import com.beotkkotthon.areyousleeping.exception.CommonException;
 import com.beotkkotthon.areyousleeping.exception.ErrorCode;
 import com.beotkkotthon.areyousleeping.service.TeamService;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
-
-import java.awt.print.Pageable;
 
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/com/beotkkotthon/areyousleeping/domain/User.java
+++ b/src/main/java/com/beotkkotthon/areyousleeping/domain/User.java
@@ -42,7 +42,7 @@ public class User {
     private LocalDateTime createdAt;
 
     /* User Info */
-    @Column(name = "nickname", nullable = false, unique = true)
+    @Column(name = "nickname", nullable = false)
     private String nickname="default_nickname";
 
     @Column(name = "profile_image_url", nullable = false)

--- a/src/main/java/com/beotkkotthon/areyousleeping/domain/UserTeam.java
+++ b/src/main/java/com/beotkkotthon/areyousleeping/domain/UserTeam.java
@@ -23,8 +23,11 @@ public class UserTeam {
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "team_id", nullable = false)
+    @JoinColumn(name = "team_id", nullable = true)
     private Team team;
+
+    @Column(name = "history_team_id", nullable = false)
+    private Long historyTeamId;
 
     @Column(name = "is_active", nullable = false)
     private Boolean isActive = false;
@@ -39,9 +42,10 @@ public class UserTeam {
     private LocalDateTime createdAt;
 
     @Builder
-    private UserTeam(User user, Team team, Boolean isLeader) {
+    private UserTeam(User user, Team team, Long historyTeamId, Boolean isLeader) {
         this.user = user;
         this.team = team;
+        this.historyTeamId = historyTeamId;
         this.isActive = false;
         this.isLeader = isLeader;
         this.lastActiveAt = null;

--- a/src/main/java/com/beotkkotthon/areyousleeping/dto/request/AuthSignUpDto.java
+++ b/src/main/java/com/beotkkotthon/areyousleeping/dto/request/AuthSignUpDto.java
@@ -12,7 +12,7 @@ public record AuthSignUpDto(
         @NotNull(message = "serial_id는 null이 될 수 없습니다.")
         @Size(min = 6, max = 254, message = "시리얼 ID는 6~254자리로 입력해주세요.")
         @Pattern(regexp = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,6}$", message = "유효하지 않은 이메일 형식입니다.")
-        String serial_id,
+        String serialId,
         @JsonProperty("password") @Schema(description = "비밀번호", example = "1234567890Aa!")
         @Pattern(
                 regexp = "^(?=.*[A-Z])(?=.*[a-z])(?=.*[0-9])(?=.*[!@#$%]).{10,20}$",

--- a/src/main/java/com/beotkkotthon/areyousleeping/dto/request/AuthSignUpDto.java
+++ b/src/main/java/com/beotkkotthon/areyousleeping/dto/request/AuthSignUpDto.java
@@ -8,11 +8,11 @@ import jakarta.validation.constraints.Size;
 
 @Schema(name = "AuthSignUpDto", description = "회원가입 요청")
 public record AuthSignUpDto(
-        @JsonProperty("serial_id") @Schema(description = "시리얼 ID", example = "kyeom")
-        @Size(min = 4, max = 20, message = "시리얼 ID는 4~20자리로 입력해주세요.")
+        @JsonProperty("serial_id") @Schema(description = "시리얼 ID", example = "example@example.com")
         @NotNull(message = "serial_id는 null이 될 수 없습니다.")
-        String serialId,
-
+        @Size(min = 6, max = 254, message = "시리얼 ID는 6~254자리로 입력해주세요.")
+        @Pattern(regexp = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,6}$", message = "유효하지 않은 이메일 형식입니다.")
+        String serial_id,
         @JsonProperty("password") @Schema(description = "비밀번호", example = "1234567890Aa!")
         @Pattern(
                 regexp = "^(?=.*[A-Z])(?=.*[a-z])(?=.*[0-9])(?=.*[!@#$%]).{10,20}$",

--- a/src/main/java/com/beotkkotthon/areyousleeping/dto/request/ChatMessageDto.java
+++ b/src/main/java/com/beotkkotthon/areyousleeping/dto/request/ChatMessageDto.java
@@ -8,7 +8,7 @@ public record ChatMessageDto(
         String type,
         @JsonProperty("content")
         String content,
-        @JsonProperty("send_time")
+        @JsonProperty("sendTime")
         String sendTime,
         @JsonProperty("sender")
         String sender)

--- a/src/main/java/com/beotkkotthon/areyousleeping/dto/response/UserTeamResponseDto.java
+++ b/src/main/java/com/beotkkotthon/areyousleeping/dto/response/UserTeamResponseDto.java
@@ -16,6 +16,7 @@ public class UserTeamResponseDto {
 
     private Long userId;
     private Long teamId;
+    private Long historyTeamId;
     private Boolean isActive;
     private Boolean isLeader;
     private LocalDateTime lastActiveAt;
@@ -26,6 +27,7 @@ public class UserTeamResponseDto {
     public UserTeamResponseDto(UserTeam userTeam){
         this.userId = userTeam.getUser().getId();
         this.teamId = userTeam.getTeam().getId();
+        this.historyTeamId = userTeam.getHistoryTeamId();
         this.isActive = userTeam.getIsActive();
         this.isLeader = userTeam.getIsActive();
         this.lastActiveAt = userTeam.getLastActiveAt();

--- a/src/main/java/com/beotkkotthon/areyousleeping/exception/ErrorCode.java
+++ b/src/main/java/com/beotkkotthon/areyousleeping/exception/ErrorCode.java
@@ -27,7 +27,7 @@ public enum ErrorCode {
     BAD_REQUEST_PARAMETER(40005, HttpStatus.BAD_REQUEST, "잘못된 요청 파라미터입니다."),
     BAD_REQUEST_JSON(40006, HttpStatus.BAD_REQUEST, "잘못된 JSON 형식입니다."),
     SEARCH_SHORT_LENGTH_ERROR(40007, HttpStatus.BAD_REQUEST, "검색어는 2글자 이상이어야 합니다."),
-
+    ALREADY_JOINED_TEAM(40008,HttpStatus.BAD_REQUEST,"사용자는 이미 팀에 속해 있습니다."),
 
 
     // Access Denied Error

--- a/src/main/java/com/beotkkotthon/areyousleeping/repository/UserTeamRepository.java
+++ b/src/main/java/com/beotkkotthon/areyousleeping/repository/UserTeamRepository.java
@@ -14,6 +14,8 @@ import java.util.List;
 
 @Repository
 public interface UserTeamRepository extends JpaRepository<UserTeam, Long> {
+
+    List<UserTeam> findAllByUserId(Long userId);
     UserTeam findByUserIdAndTeamId(Long userId, Long teamId);
 
     boolean existsByUserAndTeam(User user, Team team);

--- a/src/main/java/com/beotkkotthon/areyousleeping/service/UserTeamService.java
+++ b/src/main/java/com/beotkkotthon/areyousleeping/service/UserTeamService.java
@@ -14,7 +14,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -82,7 +81,12 @@ public class UserTeamService {
 
         // team의 현재 인원수 감소
         team.decreaseCurrentNum();
-        teamRepository.save(team);
+        // 만약 현재 인원수가 0이라면 팀 삭제
+        if (team.getCurrentNum() == 0) {
+            teamRepository.delete(team);
+        } else {
+            teamRepository.save(team);
+        }
 
         return userTeam;
     }


### PR DESCRIPTION
User Domain에서 nickname unique 속성으로 인해, "default_nickname" 인 사용자가 이미 있을 경우 오류가 발생했다.
사용자는 어차피 회원가입 과정에서 중복되지 않는 닉네임을 찾아 설정해주어야 하므로, 데이터베이스 상에서 unique 속성을 빼주는 것을 임시방편으로하여 처리하였다.

ChatMessageDto의 JsonProperty가 명세서의 "sendTime"과 달리 "send_time"으로 되어있어 수정하였다.

+ UserTeam 테이블에 유저가 속했던 팀 아이디 보존하는 historyTeamId 컬럼 추가 / 팀에 속해있을 때의 팀 생성 예외처리
