### PR TITLE
 ✨🐛 Feature/ Fix - 좋아요 토글, 좋아요한 게시물 보기 API 구현 / 커뮤니케이션 스크린 관련 버그 수정

### DIFF
--- a/.github/pull_request.md
+++ b/.github/pull_request.md
@@ -1,0 +1,14 @@
+## Related issue 🛠
+[//]: # (해당하는 이슈 번호 달아주기)
+- closed #<issue_number>
+
+## Work Description ✏️
+[//]: # (작업 내용 간단 소개)
+- 작업 내용
+
+## Uncompleted Tasks 😅
+[//]: # (없다면 N/A)
+- [ ] Task1
+
+## To Reviewers 📢
+[//]: # (reviewer가 알면 좋은 내용들)

--- a/src/main/java/com/beotkkotthon/areyousleeping/controller/CommentController.java
+++ b/src/main/java/com/beotkkotthon/areyousleeping/controller/CommentController.java
@@ -24,7 +24,8 @@ public class CommentController {
     }
     @PostMapping("")
     public ResponseDto<?> createComment(@RequestBody CommentCreateDto commentCreateDto) {
-        return ResponseDto.created(commentService.createComment(commentCreateDto));
+        commentService.createComment(commentCreateDto);
+        return ResponseDto.created(null);
     }
     @DeleteMapping("/{commentId}")
     public ResponseDto<?> deleteComment(@PathVariable Long commentId) {
@@ -33,6 +34,7 @@ public class CommentController {
     }
     @PatchMapping("/{commentId}")
     public ResponseDto<?> updateComment(@PathVariable Long commentId, @RequestBody CommentCreateDto commentCreateDto) {
-        return ResponseDto.ok(commentService.updateComment(commentId, commentCreateDto));
+        commentService.updateComment(commentId, commentCreateDto);
+        return ResponseDto.ok(null);
     }
 }

--- a/src/main/java/com/beotkkotthon/areyousleeping/controller/LikeController.java
+++ b/src/main/java/com/beotkkotthon/areyousleeping/controller/LikeController.java
@@ -17,6 +17,6 @@ public class LikeController {
     }
     @GetMapping("/api/v1/like/posts")
     public ResponseDto<?> getLikePost(Long userId) {
-        return ResponseDto.ok(likeService.getLike(userId));
+        return ResponseDto.ok(likeService.getLikedPost(userId));
     }
 }

--- a/src/main/java/com/beotkkotthon/areyousleeping/controller/LikeController.java
+++ b/src/main/java/com/beotkkotthon/areyousleeping/controller/LikeController.java
@@ -2,20 +2,24 @@ package com.beotkkotthon.areyousleeping.controller;
 
 import com.beotkkotthon.areyousleeping.dto.global.ResponseDto;
 import com.beotkkotthon.areyousleeping.service.LikeService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
 @RestController
+@RequestMapping("/api/v1/like")
+@Tag(name="Like", description = "좋아요 관련 API")
 public class LikeController {
     private final LikeService likeService;
-    @PostMapping("/api/v1/like")
+    @PostMapping("")
     public ResponseDto<?> toggleLike(Long userId, Long postId) {
         return ResponseDto.ok(likeService.toggleLike(userId, postId));
     }
-    @GetMapping("/api/v1/like/posts")
+    @GetMapping("/post")
     public ResponseDto<?> getLikePost(Long userId) {
         return ResponseDto.ok(likeService.getLikedPost(userId));
     }

--- a/src/main/java/com/beotkkotthon/areyousleeping/controller/LikeController.java
+++ b/src/main/java/com/beotkkotthon/areyousleeping/controller/LikeController.java
@@ -1,0 +1,22 @@
+package com.beotkkotthon.areyousleeping.controller;
+
+import com.beotkkotthon.areyousleeping.dto.global.ResponseDto;
+import com.beotkkotthon.areyousleeping.service.LikeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class LikeController {
+    private final LikeService likeService;
+    @PostMapping("/api/v1/like")
+    public ResponseDto<?> toggleLike(Long userId, Long postId) {
+        return ResponseDto.ok(likeService.toggleLike(userId, postId));
+    }
+    @GetMapping("/api/v1/like/posts")
+    public ResponseDto<?> getLikePost(Long userId) {
+        return ResponseDto.ok(likeService.getLike(userId));
+    }
+}

--- a/src/main/java/com/beotkkotthon/areyousleeping/controller/PostController.java
+++ b/src/main/java/com/beotkkotthon/areyousleeping/controller/PostController.java
@@ -22,9 +22,14 @@ public class PostController {
             @RequestParam(value = "keyword", required = false) String keyword) {
         return ResponseDto.ok(postService.getPost(page, size, keyword));
     }
+    @GetMapping("/{postId}")
+    public ResponseDto<?> getPostDetail(@PathVariable Long postId) {
+        return ResponseDto.ok(postService.getPostDetail(postId));
+    }
     @PostMapping("")
     public ResponseDto<?> createPost(@RequestBody PostCreateDto postCreateDto) {
-        return ResponseDto.created(postService.createPost(postCreateDto));
+        postService.createPost(postCreateDto);
+        return ResponseDto.created(null);
     }
 
     @DeleteMapping("/{postId}")
@@ -35,6 +40,7 @@ public class PostController {
 
     @PatchMapping("/{postId}")
     public ResponseDto<?> updatePost(@PathVariable Long postId, @RequestBody PostUpdateDto postUpdateDto) {
-        return ResponseDto.ok(postService.updatePost(postId, postUpdateDto));
+        postService.updatePost(postId, postUpdateDto);
+        return ResponseDto.ok(null);
     }
 }

--- a/src/main/java/com/beotkkotthon/areyousleeping/domain/Comment.java
+++ b/src/main/java/com/beotkkotthon/areyousleeping/domain/Comment.java
@@ -22,7 +22,7 @@ public class Comment {
     @JoinColumn(name = "post_id", nullable = false)
     private Post post;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 

--- a/src/main/java/com/beotkkotthon/areyousleeping/domain/Post.java
+++ b/src/main/java/com/beotkkotthon/areyousleeping/domain/Post.java
@@ -18,7 +18,7 @@ public class Post {
     @Column(name="post_id")
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
@@ -40,6 +40,7 @@ public class Post {
         this.user = user;
         this.postContent = postContent;
         this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
     }
 
     public void update(String postTitle, String postContent) {

--- a/src/main/java/com/beotkkotthon/areyousleeping/domain/specification/PostSpecifications.java
+++ b/src/main/java/com/beotkkotthon/areyousleeping/domain/specification/PostSpecifications.java
@@ -7,7 +7,7 @@ public class PostSpecifications {
     public static Specification<Post> hasKeyword(String keyword) {
         return (root, query, cb) -> {
             if (keyword == null || keyword.trim().isEmpty()) return null;
-            return cb.like(cb.lower(root.get("title")), "%" + keyword.toLowerCase() + "%");
+            return cb.like(cb.lower(root.get("postTitle")), "%" + keyword.toLowerCase() + "%");
         };
     }
 }

--- a/src/main/java/com/beotkkotthon/areyousleeping/dto/response/CommentResponseDto.java
+++ b/src/main/java/com/beotkkotthon/areyousleeping/dto/response/CommentResponseDto.java
@@ -1,21 +1,36 @@
 package com.beotkkotthon.areyousleeping.dto.response;
 
 import com.beotkkotthon.areyousleeping.domain.Comment;
+import com.beotkkotthon.areyousleeping.domain.User;
 import lombok.Builder;
+
+import java.util.List;
 
 @Builder
 public record CommentResponseDto(
         Long commentId,
+        Long userId,
+        String nickname,
+        String profileImageUrl,
         String commentContent,
         String createdAt,
         String updatedAt
 ) {
-    public static CommentResponseDto fromEntity(Comment comment) {
+    public static CommentResponseDto fromEntity(Comment comment, User user) {
         return CommentResponseDto.builder()
                 .commentId(comment.getId())
+                .userId(user.getId())
+                .nickname(user.getNickname())
+                .profileImageUrl(user.getProfileImageUrl())
                 .commentContent(comment.getCommentContent())
                 .createdAt(comment.getCreatedAt().toString())
                 .updatedAt(comment.getUpdatedAt().toString())
                 .build();
     }
+    public static List<CommentResponseDto> fromEntities(List<Comment> comments, List<User> users) {
+        return comments.stream()
+                .map(comment -> CommentResponseDto.fromEntity(comment, users.get(comments.indexOf(comment))))
+                .toList();
+    }
+
 }

--- a/src/main/java/com/beotkkotthon/areyousleeping/dto/response/PostDetailResponseDto.java
+++ b/src/main/java/com/beotkkotthon/areyousleeping/dto/response/PostDetailResponseDto.java
@@ -12,6 +12,7 @@ public record PostDetailResponseDto(
         Long postId,
         String postTitle,
         String postContent,
+        Integer likeCount,
         Long userId,
         String nickname,
         String profileImageUrl,
@@ -19,11 +20,12 @@ public record PostDetailResponseDto(
         String updatedAt,
         List<CommentResponseDto> commentsDto
 ) {
-    public static PostDetailResponseDto fromEntity(Post post, List<Comment> comments) {
+    public static PostDetailResponseDto fromEntity(Post post, List<Comment> comments, Integer likeCount) {
         return PostDetailResponseDto.builder()
                 .postId(post.getId())
                 .postTitle(post.getPostTitle())
                 .postContent(post.getPostContent())
+                .likeCount(likeCount)
                 .userId(post.getUser().getId())
                 .nickname(post.getUser().getNickname())
                 .profileImageUrl(post.getUser().getProfileImageUrl())

--- a/src/main/java/com/beotkkotthon/areyousleeping/dto/response/PostDetailResponseDto.java
+++ b/src/main/java/com/beotkkotthon/areyousleeping/dto/response/PostDetailResponseDto.java
@@ -1,26 +1,35 @@
 package com.beotkkotthon.areyousleeping.dto.response;
 
+import com.beotkkotthon.areyousleeping.domain.Comment;
 import com.beotkkotthon.areyousleeping.domain.Post;
 import com.beotkkotthon.areyousleeping.domain.User;
 import lombok.Builder;
 
+import java.util.List;
+
 @Builder
-public record PostResponseDto(
+public record PostDetailResponseDto(
         Long postId,
         String postTitle,
+        String postContent,
         Long userId,
         String nickname,
         String profileImageUrl,
-        String createdAt
+        String createdAt,
+        String updatedAt,
+        List<CommentResponseDto> commentsDto
 ) {
-    public static PostResponseDto fromEntity(Post post) {
-        return PostResponseDto.builder()
+    public static PostDetailResponseDto fromEntity(Post post, List<Comment> comments) {
+        return PostDetailResponseDto.builder()
                 .postId(post.getId())
                 .postTitle(post.getPostTitle())
+                .postContent(post.getPostContent())
                 .userId(post.getUser().getId())
                 .nickname(post.getUser().getNickname())
                 .profileImageUrl(post.getUser().getProfileImageUrl())
                 .createdAt(post.getCreatedAt().toString())
+                .updatedAt(post.getUpdatedAt().toString())
+                .commentsDto(CommentResponseDto.fromEntities(comments, List.of(post.getUser())))
                 .build();
     }
 }

--- a/src/main/java/com/beotkkotthon/areyousleeping/dto/response/PostResponseDto.java
+++ b/src/main/java/com/beotkkotthon/areyousleeping/dto/response/PostResponseDto.java
@@ -1,5 +1,6 @@
 package com.beotkkotthon.areyousleeping.dto.response;
 
+import com.beotkkotthon.areyousleeping.domain.Like;
 import com.beotkkotthon.areyousleeping.domain.Post;
 import com.beotkkotthon.areyousleeping.domain.User;
 import lombok.Builder;
@@ -8,15 +9,17 @@ import lombok.Builder;
 public record PostResponseDto(
         Long postId,
         String postTitle,
+        Integer likeCount,
         Long userId,
         String nickname,
         String profileImageUrl,
         String createdAt
 ) {
-    public static PostResponseDto fromEntity(Post post) {
+    public static PostResponseDto fromEntity(Post post, Integer likeCount) {
         return PostResponseDto.builder()
                 .postId(post.getId())
                 .postTitle(post.getPostTitle())
+                .likeCount(likeCount)
                 .userId(post.getUser().getId())
                 .nickname(post.getUser().getNickname())
                 .profileImageUrl(post.getUser().getProfileImageUrl())

--- a/src/main/java/com/beotkkotthon/areyousleeping/repository/CommentRepository.java
+++ b/src/main/java/com/beotkkotthon/areyousleeping/repository/CommentRepository.java
@@ -6,7 +6,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     Page<Comment> findAllByPostId(Long postId, Pageable pageable);
+    List<Comment> findAllByPostId(Long postId);
 }

--- a/src/main/java/com/beotkkotthon/areyousleeping/repository/LikeRepository.java
+++ b/src/main/java/com/beotkkotthon/areyousleeping/repository/LikeRepository.java
@@ -1,6 +1,7 @@
 package com.beotkkotthon.areyousleeping.repository;
 
 import com.beotkkotthon.areyousleeping.domain.Like;
+import com.beotkkotthon.areyousleeping.domain.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -11,4 +12,5 @@ import java.util.Optional;
 public interface LikeRepository extends JpaRepository<Like,Long> {
     Optional<Like> findByPostIdAndUserId(Long postId, Long userId);
     List<Like> findAllByUserId(Long userId);
+    Integer countByPost(Post post);
 }

--- a/src/main/java/com/beotkkotthon/areyousleeping/repository/LikeRepository.java
+++ b/src/main/java/com/beotkkotthon/areyousleeping/repository/LikeRepository.java
@@ -4,6 +4,11 @@ import com.beotkkotthon.areyousleeping.domain.Like;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+import java.util.Optional;
+
 @Repository
 public interface LikeRepository extends JpaRepository<Like,Long> {
+    Optional<Like> findByPostIdAndUserId(Long postId, Long userId);
+    List<Like> findAllByUserId(Long userId);
 }

--- a/src/main/java/com/beotkkotthon/areyousleeping/service/CommentService.java
+++ b/src/main/java/com/beotkkotthon/areyousleeping/service/CommentService.java
@@ -32,16 +32,16 @@ public class CommentService {
         Page<Comment> comments = commentRepository.findAllByPostId(postId, pageable);
 
         return comments.getContent().stream()
-                .map(CommentResponseDto::fromEntity)
+                .map(comment -> CommentResponseDto.fromEntity(comment, comment.getUser()))
                 .collect(Collectors.toList());
     }
 
-    public Comment createComment(CommentCreateDto commentCreateDto) {
+    public void createComment(CommentCreateDto commentCreateDto) {
         User user = userRepository.findById(commentCreateDto.userId())
                 .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_USER));
         Post post = postRepository.findById(commentCreateDto.postId())
                 .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_POST));
-        return commentRepository.save(
+        commentRepository.save(
                 Comment.builder()
                         .user(user)
                         .post(post)
@@ -53,12 +53,12 @@ public class CommentService {
                 .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_COMMENT));
         commentRepository.delete(comment);
     }
-    public Comment updateComment(Long commentId, CommentCreateDto commentCreateDto) {
+    public void updateComment(Long commentId, CommentCreateDto commentCreateDto) {
         Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_COMMENT));
         comment.update(
                 commentCreateDto.commentContent()
         );
-        return commentRepository.save(comment);
+        commentRepository.save(comment);
     }
 }

--- a/src/main/java/com/beotkkotthon/areyousleeping/service/LikeService.java
+++ b/src/main/java/com/beotkkotthon/areyousleeping/service/LikeService.java
@@ -36,10 +36,13 @@ public class LikeService {
                     return "Like added";
                 });
     }
-    public List<PostResponseDto> getLike(Long userId) {
+    public List<PostResponseDto> getLikedPost(Long userId) {
          return likeRepository.findAllByUserId(userId).stream()
                  .map(Like::getPost)
-                 .map(PostResponseDto::fromEntity)
+                 .map(post -> {
+                     Integer likeCount = likeRepository.countByPost(post);
+                        return PostResponseDto.fromEntity(post, likeCount);
+                 })
                  .toList();
     }
 }

--- a/src/main/java/com/beotkkotthon/areyousleeping/service/LikeService.java
+++ b/src/main/java/com/beotkkotthon/areyousleeping/service/LikeService.java
@@ -1,0 +1,40 @@
+package com.beotkkotthon.areyousleeping.service;
+
+import com.beotkkotthon.areyousleeping.domain.Like;
+import com.beotkkotthon.areyousleeping.dto.response.PostResponseDto;
+import com.beotkkotthon.areyousleeping.exception.CommonException;
+import com.beotkkotthon.areyousleeping.exception.ErrorCode;
+import com.beotkkotthon.areyousleeping.repository.LikeRepository;
+import com.beotkkotthon.areyousleeping.repository.PostRepository;
+import com.beotkkotthon.areyousleeping.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+@RequiredArgsConstructor
+@Service
+public class LikeService {
+    private final LikeRepository likeRepository;
+    private final UserRepository userRepository;
+    private final PostRepository postRepository;
+
+    public String toggleLike(Long userId, Long postId) {
+        likeRepository.findByPostIdAndUserId(postId, userId)
+                .ifPresentOrElse(likeRepository::delete,
+                        () -> likeRepository.save(Like.builder()
+                                    .user(userRepository.findById(userId)
+                                            .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_USER)))
+                                    .post(postRepository.findById(postId)
+                                            .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_POST)))
+                                    .build())
+                );
+    }
+    public List<PostResponseDto> getLike(Long userId) {
+         return likeRepository.findAllByUserId(userId).stream()
+                 .map(Like::getPost)
+                 .map(PostResponseDto::fromEntity)
+                 .toList();
+    }
+}

--- a/src/main/java/com/beotkkotthon/areyousleeping/service/LikeService.java
+++ b/src/main/java/com/beotkkotthon/areyousleeping/service/LikeService.java
@@ -21,15 +21,20 @@ public class LikeService {
     private final PostRepository postRepository;
 
     public String toggleLike(Long userId, Long postId) {
-        likeRepository.findByPostIdAndUserId(postId, userId)
-                .ifPresentOrElse(likeRepository::delete,
-                        () -> likeRepository.save(Like.builder()
-                                    .user(userRepository.findById(userId)
-                                            .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_USER)))
-                                    .post(postRepository.findById(postId)
-                                            .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_POST)))
-                                    .build())
-                );
+        return likeRepository.findByPostIdAndUserId(postId, userId)
+                .map(like -> {
+                    likeRepository.delete(like);
+                    return "Like removed";
+                })
+                .orElseGet(() -> {
+                    likeRepository.save(Like.builder()
+                            .user(userRepository.findById(userId)
+                                    .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_USER)))
+                            .post(postRepository.findById(postId)
+                                    .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_POST)))
+                            .build());
+                    return "Like added";
+                });
     }
     public List<PostResponseDto> getLike(Long userId) {
          return likeRepository.findAllByUserId(userId).stream()

--- a/src/main/java/com/beotkkotthon/areyousleeping/service/MissionService.java
+++ b/src/main/java/com/beotkkotthon/areyousleeping/service/MissionService.java
@@ -62,20 +62,18 @@ public class MissionService {
             UserTeam userTeam = userTeamRepository.findByUserIdAndTeamId(userId, teamId);
             UserTeam lastUserTeam = userTeamRepository.findAllByUserIdOrderByCreatedAtDesc(userId).get(1);
             Integer teamUsersCount = teamRepository.findById(teamId).orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_TEAM)).getCurrentNum();
-
-            achievementRateRepository.findByUserId(userId).updateAchievementRate(userTeam, lastUserTeam, teamUsersCount);
+            userTeam.updateFailCount(); // 해당 userTeam에서의 미션 실패 회수 추가
 
             if(userTeam.getContinueMissionFailedCount() == 1) { // 이전 미션이 실패했었으면
+                achievementRateRepository.findByUserId(userId).updateAchievementRate(userTeam, lastUserTeam, teamUsersCount); // achievementRate 업데이트
+
                 User user = userRepository.findById(userId).orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_USER));
+                AchievementRate updatedAchievementRate = achievementRateRepository.findByUserId(userId); // 업데이트가 반영된 achievementRate 다시조회
                 achievementRepository.findByUserId(userId).forEach(achievement ->
-                        achievement.renewalAchievements(user,
-                                AchievementRateDto.fromEntity(
-                                        achievementRateRepository.findByUserId(userId)
-                                )
+                        achievement.renewalAchievements(user, // 칭호 갱신
+                                AchievementRateDto.fromEntity(updatedAchievementRate)
                         )
                 );
-
-                userTeam.updateFailCount();
                 userTeam.updateByQuit();
             }
         }
@@ -96,20 +94,18 @@ public class MissionService {
             UserTeam userTeam = userTeamRepository.findByUserIdAndTeamId(userId, teamId);
             UserTeam lastUserTeam = userTeamRepository.findAllByUserIdOrderByCreatedAtDesc(userId).get(1);
             Integer teamUsersCount = teamRepository.findById(teamId).orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_TEAM)).getCurrentNum();
-
-            achievementRateRepository.findByUserId(userId).updateAchievementRate(userTeam, lastUserTeam, teamUsersCount);
+            userTeam.updateFailCount(); // 해당 userTeam에서의 미션 실패 회수 추가
 
             if(userTeam.getContinueMissionFailedCount() == 1) { // 이전 미션이 실패했었으면
+                achievementRateRepository.findByUserId(userId).updateAchievementRate(userTeam, lastUserTeam, teamUsersCount); // achievementRate 업데이트
+
                 User user = userRepository.findById(userId).orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_USER));
+                AchievementRate updatedAchievementRate = achievementRateRepository.findByUserId(userId); // 업데이트가 반영된 achievementRate 다시조회
                 achievementRepository.findByUserId(userId).forEach(achievement ->
-                        achievement.renewalAchievements(user,
-                                AchievementRateDto.fromEntity(
-                                        achievementRateRepository.findByUserId(userId)
-                                )
+                        achievement.renewalAchievements(user, // 칭호 갱신
+                                AchievementRateDto.fromEntity(updatedAchievementRate)
                         )
                 );
-
-                userTeam.updateFailCount();
                 userTeam.updateByQuit();
             }
         }

--- a/src/main/java/com/beotkkotthon/areyousleeping/service/PostService.java
+++ b/src/main/java/com/beotkkotthon/areyousleeping/service/PostService.java
@@ -57,12 +57,11 @@ public class PostService {
         Map<String, Object> result = new HashMap<>();
         result.put("hasNext", posts.hasNext());
         result.put("posts", posts.getContent().stream()
-
                         .map(post -> {
                             Integer likeCount = likeRepository.countByPost(post);
                             return PostResponseDto.fromEntity(post, likeCount);
-                        }
-                                .toList());
+                        })
+                        .toList());
 
 
         return result;
@@ -71,7 +70,8 @@ public class PostService {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_POST));
         List<Comment> comments = commentRepository.findAllByPostId(postId);
-        return PostDetailResponseDto.fromEntity(post, comments);
+        Integer likeCount = likeRepository.countByPost(post);
+        return PostDetailResponseDto.fromEntity(post, comments, likeCount);
     }
 
     public void deletePost(Long postId) {

--- a/src/main/java/com/beotkkotthon/areyousleeping/service/PostService.java
+++ b/src/main/java/com/beotkkotthon/areyousleeping/service/PostService.java
@@ -1,13 +1,16 @@
 package com.beotkkotthon.areyousleeping.service;
 
+import com.beotkkotthon.areyousleeping.domain.Comment;
 import com.beotkkotthon.areyousleeping.domain.Post;
 import com.beotkkotthon.areyousleeping.domain.User;
 import com.beotkkotthon.areyousleeping.domain.specification.PostSpecifications;
 import com.beotkkotthon.areyousleeping.dto.request.PostCreateDto;
 import com.beotkkotthon.areyousleeping.dto.request.PostUpdateDto;
+import com.beotkkotthon.areyousleeping.dto.response.PostDetailResponseDto;
 import com.beotkkotthon.areyousleeping.dto.response.PostResponseDto;
 import com.beotkkotthon.areyousleeping.exception.CommonException;
 import com.beotkkotthon.areyousleeping.exception.ErrorCode;
+import com.beotkkotthon.areyousleeping.repository.CommentRepository;
 import com.beotkkotthon.areyousleeping.repository.PostRepository;
 import com.beotkkotthon.areyousleeping.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +22,7 @@ import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -27,11 +31,12 @@ import java.util.stream.Collectors;
 public class PostService {
     private final PostRepository postRepository;
     private final UserRepository userRepository;
+    private final CommentRepository commentRepository;
 
-    public Post createPost(PostCreateDto postCreateDto) {
+    public void createPost(PostCreateDto postCreateDto) {
         User user = userRepository.findById(postCreateDto.userId())
                 .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_USER));
-        return postRepository.save(
+        postRepository.save(
                 Post.builder()
                         .postTitle(postCreateDto.title())
                         .postContent(postCreateDto.content())
@@ -55,6 +60,12 @@ public class PostService {
 
         return result;
     }
+    public PostDetailResponseDto getPostDetail(Long postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_POST));
+        List<Comment> comments = commentRepository.findAllByPostId(postId);
+        return PostDetailResponseDto.fromEntity(post, comments);
+    }
 
     public void deletePost(Long postId) {
         Post post = postRepository.findById(postId)
@@ -62,11 +73,11 @@ public class PostService {
         postRepository.delete(post);
     }
 
-    public Post updatePost(Long postId, PostUpdateDto postUpdateDto) {
+    public void updatePost(Long postId, PostUpdateDto postUpdateDto) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_POST));
         post.update(postUpdateDto.title(), postUpdateDto.content());
 
-        return postRepository.save(post);
+        postRepository.save(post);
     }
 }

--- a/src/main/java/com/beotkkotthon/areyousleeping/service/PostService.java
+++ b/src/main/java/com/beotkkotthon/areyousleeping/service/PostService.java
@@ -11,6 +11,7 @@ import com.beotkkotthon.areyousleeping.dto.response.PostResponseDto;
 import com.beotkkotthon.areyousleeping.exception.CommonException;
 import com.beotkkotthon.areyousleeping.exception.ErrorCode;
 import com.beotkkotthon.areyousleeping.repository.CommentRepository;
+import com.beotkkotthon.areyousleeping.repository.LikeRepository;
 import com.beotkkotthon.areyousleeping.repository.PostRepository;
 import com.beotkkotthon.areyousleeping.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -32,6 +33,7 @@ public class PostService {
     private final PostRepository postRepository;
     private final UserRepository userRepository;
     private final CommentRepository commentRepository;
+    private final LikeRepository likeRepository;
 
     public void createPost(PostCreateDto postCreateDto) {
         User user = userRepository.findById(postCreateDto.userId())
@@ -55,8 +57,13 @@ public class PostService {
         Map<String, Object> result = new HashMap<>();
         result.put("hasNext", posts.hasNext());
         result.put("posts", posts.getContent().stream()
-                .map(PostResponseDto::fromEntity)
-                .collect(Collectors.toList()));
+
+                        .map(post -> {
+                            Integer likeCount = likeRepository.countByPost(post);
+                            return PostResponseDto.fromEntity(post, likeCount);
+                        }
+                                .toList());
+
 
         return result;
     }


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
- #48 

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- 게시글에 대한 좋아요 기능을 구현했습니다. 사용자는 커뮤니티에 들어가 원하는 게시글에 좋아요를 누를 수 있으며, 좋아요 수는 게시글을 기준으로 현재 좋아요가 눌러진 사람의 수 만큼 카운팅됩니다. 또한 사용자는 자신이 좋아요 한 게시물을 모아서 볼 수 있습니다.
- 게시글 리스트 조회 시, 유저 정보와 좋아요 수가 함께 전달되도록 Response Body를 수정했습니다.
- 게시글 상세보기 시, 유저 정보와 좋아요 수, 댓글이 함께 전달되도록 Response Body를 수정했습니다.
- 커뮤니케이션 스크린 관련하여, 게시글과 댓글에 포함된 User를 Lazy 로딩으로 불러오기에 발생했던 문제가 있었습니다. 로딩 방식을 EAGER로 수정하여 해결했습니다.
- 커뮤니케이션 스크린 관련하여, 게시글 제목 검색을 통한 불러오기에서 specification의 잘못된 컬럼 명 참조로 서버 오류가 발생했었습니다. title -> postTitle로 수정하여 해결했습니다.

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)
